### PR TITLE
Terraform DigitalOcean

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,56 @@
+# Deployment
+
+## DigitalOcean
+
+### Terraform
+
+#### Prerequisites
+
+- [DigitalOcean Personal Access Token](https://www.digitalocean.com/docs/apis-clis/api/create-personal-access-token)
+- [GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
+
+#### Prepare envars
+
+- `DO_PAT` – DigitalOcean Personal Access Token
+- `DO_VPC` (optional) – UUID of a DigitalOcean Virtual Private Cloud (VPC).
+  Obtain it via
+  [DO's API](https://developers.digitalocean.com/documentation/v2/#list-all-vpcs).
+  Leave empty to add the resource to the default project.
+- `TERRAFORM_SSH_KEY` – Path to the passphrase-free SSH private key that's been
+  added to DigitalOcean for use with Terraform provisioning. E.g.
+  `$HOME/.ssh/id_ed25519_digitalocean_terraform`.
+- `GH_USERNAME` – GitHub username used for logging in to GitHub Container
+  Registry (`ghcr.io`).
+- `GH_PAT` – GitHub Personal Access Token used for authenticating with
+  `ghcr.io`.
+
+```console
+export DO_PAT=
+export DO_VPC=
+export TERRAFORM_SSH_KEY=
+export GH_USERNAME=
+export GH_PAT=
+```
+
+#### `plan` and `apply`
+
+```console
+cd terraform/digitalocean
+terraform plan \
+    -var "do_token=${DO_PAT}" \
+    -var "vpc_uuid=${DO_VPC}" \
+    -var "private_ssh_key=${TERRAFORM_SSH_KEY}" \
+    -var "gh_username=${GH_USERNAME}" \
+    -var "gh_pat=${GH_PAT}"
+```
+
+Analyse the above plan, and if all looks good, run `apply`:
+
+```console
+terraform apply \
+    -var "do_token=${DO_PAT}" \
+    -var "vpc_uuid=${DO_VPC}" \
+    -var "private_ssh_key=${TERRAFORM_SSH_KEY}" \
+    -var "gh_username=${GH_USERNAME}" \
+    -var "gh_pat=${GH_PAT}"
+```

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,3 @@
+.terraform/
+.terraform*
+**.tfstate*

--- a/terraform/digitalocean/main.tf
+++ b/terraform/digitalocean/main.tf
@@ -1,0 +1,53 @@
+variable "image_type" {
+  # https://slugs.do-api.dev
+  default = "docker-20-04"
+}
+variable "region" {
+  # https://slugs.do-api.dev
+  default = "fra1"
+}
+variable "size" {
+  # https://slugs.do-api.dev
+  default = "s-1vcpu-1gb"
+}
+variable "vpc_uuid" {
+  # UUID of the DigitalOcean project. Leave empty to add the resource to the default project.
+  # Use the API to obtain the list of VPCs: https://developers.digitalocean.com/documentation/v2/#list-all-vpcs
+  default = ""
+}
+variable "gh_username" {
+  # GitHub username used for logging in to Container Registry.
+  # Provided in the CLI.
+}
+variable "gh_pat" {
+  # GitHub Personal Access Token for authenticating with Container Registry.
+  # Provided in the CLI.
+}
+
+resource "digitalocean_droplet" "gg-bot" {
+  image = var.image_type
+  name = "GG-Bot-Terraform"
+  region = var.region
+  size = var.size
+  vpc_uuid = var.vpc_uuid
+  private_networking = true
+  ssh_keys = [
+    data.digitalocean_ssh_key.terraform.id
+  ]
+
+  connection {
+    host = self.ipv4_address
+    user = "root"
+    type = "ssh"
+    private_key = file(var.private_ssh_key)
+    timeout = "2m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "export PATH=$PATH:/usr/bin",
+      "echo '${var.gh_pat}' | docker login --username '${var.gh_username}' --password-stdin 'ghcr.io'",
+      "docker pull 'ghcr.io/amrwc/gg-bot/ggbot:latest'"
+    ]
+  }
+}

--- a/terraform/digitalocean/provider.tf
+++ b/terraform/digitalocean/provider.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "2.6.0"
+    }
+  }
+}
+
+variable "do_token" {
+  # DigitalOcean Personal Access Token. 
+  # Provided in the CLI. 
+}
+variable "private_ssh_key" {
+  # Path to the SSH key which can access DO services.
+  # Provided in the CLI.
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+# Automatically add the SSH key to any new Droplets created.
+# NOTE: Replace `id_ed25519_digitalocean_terraform` with the SSH key name added to DigitalOcean.
+data "digitalocean_ssh_key" "terraform" {
+  name = "id_ed25519_digitalocean_terraform"
+}


### PR DESCRIPTION
- [x] Create a Docker-Ubuntu droplet.
- [x] Prototype provisioning – log into GitHub Container Registry, and pull `ggbot` container.
- [ ] Create the droplet in the specified VPC – for some reason it still created it in the default project.
- [ ] Provision the database container. (Don't use the managed database, as it costs another $15/mo – just spin up another Docker container, like when running it locally. 🤷)
- [ ] Apply database migrations. This will probably require a Java Docker container as to not install Java in the droplet for no good reason. Or, consider running Liquibase locally, as would perhaps happen in a proper application anyway.
- [ ] Test it end-to-end.
- [ ] Lint the scripts.
- [ ] Add linter to the repository? 🤔