### PR TITLE
Change Image Cache Name in Docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,28 +3,29 @@ name: Docker
 on:
   push:
     paths:
-      - '.github/workflows/docker.yml'
-      - 'bin/**'
-      - 'docker/**'
-      - 'gradle/**'
-      - 'src/main/**.java'
-      - 'src/main/resources/**'
-      - 'build.gradle'
-      - 'gradle.properties'
-      - 'settings.gradle'
+      - .github/workflows/docker.yml
+      - bin/**
+      - docker/**
+      - gradle/**
+      - src/main/**.java
+      - src/main/resources/**
+      - build.gradle
+      - gradle.properties
+      - settings.gradle
 
 env:
-  USE_CACHE: 'true'
-  MAIN_IMAGE: 'ggbot'
-  REGISTRY: 'ghcr.io'
-  TMP_CACHE: 'cache-tmp'
+  MAIN_IMAGE: ggbot
+  REGISTRY: ghcr.io
+  TMP_CACHE: cache-tmp
+  USE_DOCKER_CACHE: ${{ secrets.USE_DOCKER_CACHE }}
 
+  # To be executed as a step
   SET_VARIABLES: |
-    if [ 'true' = "$USE_CACHE" ]; then
-      build_image="${MAIN_IMAGE}-gradle-build"
-      echo "BUILD_IMAGE=${build_image}" >> $GITHUB_ENV
-      echo "BUILD_CONTAINER_CACHE=${REGISTRY}/${{ github.repository }}/${build_image}" >> $GITHUB_ENV
-      echo "MAIN_CONTAINER_CACHE=${REGISTRY}/${{ github.repository }}/${MAIN_IMAGE}" >> $GITHUB_ENV
+    if [ 'true' = "$USE_DOCKER_CACHE" ]; then
+        build_image="${MAIN_IMAGE}-gradle-build"
+        echo "BUILD_IMAGE=${build_image}" >> $GITHUB_ENV
+        echo "BUILD_IMAGE_CACHE=${REGISTRY}/${{ github.repository }}/${build_image}-cache" >> $GITHUB_ENV
+        echo "MAIN_IMAGE_CACHE=${REGISTRY}/${{ github.repository }}/${MAIN_IMAGE}-cache" >> $GITHUB_ENV
     fi
 
 jobs:
@@ -47,32 +48,29 @@ jobs:
 
       - name: Install Python requirements
         run: |
-          sudo python3 -m pip install -U pip
-          sudo python3 -m pip install -U setuptools
+          python3 -m pip install -U pip
+          python3 -m pip install -U setuptools
           pip3 install -r ./bin/requirements.txt
 
       - name: Set variables
         run: ${{ env.SET_VARIABLES }}
 
       - name: Log into GitHub Container Registry
+        if: ${{ 'true' == env.USE_DOCKER_CACHE }}
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.CONTAINER_REGISTRY_TOKEN }}
 
       - name: Pull cached images
-        if: ${{ 'true' == env.USE_CACHE }}
+        if: ${{ 'true' == env.USE_DOCKER_CACHE }}
         run: |
-          docker pull "$BUILD_CONTAINER_CACHE" || echo "::warning::Failed to pull ${BUILD_CONTAINER_CACHE}"
-          docker pull "$MAIN_CONTAINER_CACHE" || echo "::warning::Failed to pull ${MAIN_CONTAINER_CACHE}"
+          docker pull "$BUILD_IMAGE_CACHE" || echo "::warning::Failed to pull ${BUILD_IMAGE_CACHE}"
+          docker pull "$MAIN_IMAGE_CACHE" || echo "::warning::Failed to pull ${MAIN_IMAGE_CACHE}"
 
       - name: Build and run the container
         run: |
-          if [ 'true' = "$USE_CACHE" ]; then
-            cache_from="--cache-from ${BUILD_CONTAINER_CACHE} --cache-from ${MAIN_CONTAINER_CACHE}"
-          fi
-
           # Set required envars
           export POSTGRES_URL='jdbc:postgresql://localhost:5432'
           export POSTGRES_DB='ggbot'
@@ -81,23 +79,28 @@ jobs:
 
           export SPRING_DATASOURCE_URL='jdbc:postgresql://ggbot-database:5432/ggbot'
           export SPRING_DATASOURCE_USERNAME='spring_user'
+          # This password must match the default one in the initial migrations
           export SPRING_DATASOURCE_PASSWORD='SpringUserPassword'
+
+          if [ 'true' = "$USE_DOCKER_CACHE" ]; then
+              cache_from="--cache-from ${BUILD_IMAGE_CACHE} --cache-from ${MAIN_IMAGE_CACHE}"
+          fi
 
           # shellcheck disable=SC2086
           ./bin/run.py --apply-migrations --detach $cache_from
 
-      - name: Tag and push the images
-        if: ${{ 'true' == env.USE_CACHE }}
+      - name: Tag and push the cache images
+        if: ${{ 'true' == env.USE_DOCKER_CACHE }}
         run: |
-          if docker tag "$BUILD_IMAGE" "$BUILD_CONTAINER_CACHE"; then
-            docker push "$BUILD_CONTAINER_CACHE" || echo "::warning::Failed to push ${BUILD_CONTAINER_CACHE}"
+          if docker tag "$BUILD_IMAGE" "$BUILD_IMAGE_CACHE"; then
+              docker push "$BUILD_IMAGE_CACHE" || echo "::warning::Failed to push ${BUILD_IMAGE_CACHE}"
           else
-            echo "::warning::Failed to tag ${BUILD_IMAGE}"
+              echo "::warning::Failed to tag ${BUILD_IMAGE}"
           fi
-          if docker tag "$MAIN_IMAGE" "$MAIN_CONTAINER_CACHE"; then
-            docker push "$MAIN_CONTAINER_CACHE" || echo "::warning::Failed to push ${MAIN_CONTAINER_CACHE}"
+          if docker tag "$MAIN_IMAGE" "$MAIN_IMAGE_CACHE"; then
+              docker push "$MAIN_IMAGE_CACHE" || echo "::warning::Failed to push ${MAIN_IMAGE_CACHE}"
           else
-            echo "::warning::Failed to tag ${MAIN_IMAGE}"
+              echo "::warning::Failed to tag ${MAIN_IMAGE}"
           fi
 
       - name: Test the API

--- a/docs/setup-instructions.md
+++ b/docs/setup-instructions.md
@@ -34,8 +34,8 @@ ALTER USER spring_user WITH PASSWORD '<new_password>';
 
 ## GitHub Workflows
 
-Add `CR_PAT` secret to the repository to be able to sign into container
-registry. Read more on this in [GitHub's
+Add `CONTAINER_REGISTRY_TOKEN` secret to the repository to be able to sign into
+container registry. Read more on this in [GitHub's
 documentation][github_auth_container_registry].
 
 [discord_developer_portal]: https://discord.com/developers/applications


### PR DESCRIPTION
- Change Docker pipeline to not use the `ggbot` image name when caching the test images.
- Move `USE_DOCKER_CACHE` flag into the repository's secret.